### PR TITLE
Remove DatatypeConverter as it breaks with java 9, fixes #15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,11 @@
             <artifactId>commons-io</artifactId>
             <version>1.3.2</version>
         </dependency>
+	<dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.9.9</version>
+	</dependency>
     </dependencies>
     <reporting>
         <excludeDefaults>true</excludeDefaults>

--- a/src/main/java/com/ardoq/adapter/Iso8601Adapter.java
+++ b/src/main/java/com/ardoq/adapter/Iso8601Adapter.java
@@ -2,23 +2,20 @@ package com.ardoq.adapter;
 
 import com.google.gson.*;
 
-import javax.xml.bind.DatatypeConverter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.joda.time.DateTime;
 import java.lang.reflect.Type;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 
 public class Iso8601Adapter implements JsonDeserializer<Date>, JsonSerializer<Date> {
 
     public Date deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
-        Calendar calendar = DatatypeConverter.parseDateTime(jsonElement.getAsString());
-        return calendar.getTime();
+        DateTime dt = ISODateTimeFormat.dateTimeParser().parseDateTime(jsonElement.getAsString());
+        return dt.toDate();
     }
 
     public JsonElement serialize(Date date, Type type, JsonSerializationContext jsonSerializationContext) {
-        GregorianCalendar gregorianCalendar = new GregorianCalendar();
-        gregorianCalendar.setTime(date);
-        String s = DatatypeConverter.printDateTime(gregorianCalendar);
+        String s = ISODateTimeFormat.dateTime().print(new DateTime(date));
         return new JsonPrimitive(s);
     }
 }

--- a/src/test/java/com/ardoq/adapter/Iso8601AdapterTest.java
+++ b/src/test/java/com/ardoq/adapter/Iso8601AdapterTest.java
@@ -1,0 +1,28 @@
+package com.ardoq.adapter;
+
+import com.google.gson.*;
+
+import org.junit.Test;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+public class Iso8601AdapterTest {
+
+    Iso8601Adapter sut = new Iso8601Adapter();
+
+    @Test
+    public void testSerde() {
+        Date orig = new Date();
+        Date d = sut.deserialize(sut.serialize(orig, null, null), null, null);
+        assertEquals(orig, d);
+    }
+
+    @Test
+    public void testSerialization() {
+        Gson gson = new Gson();
+        JsonElement orig = gson.fromJson("\"2014-04-07T09:12:06.323+02:00\"", JsonElement.class);
+        JsonElement e = sut.serialize(sut.deserialize(orig, null, null), null, null);
+        assertEquals(orig.getAsString(), e.getAsString());
+    }
+}


### PR DESCRIPTION
- Add joda-time as a dependency
- Use joda-time to parse/format dates
- Add tests