### PR TITLE
fixed possible null fields

### DIFF
--- a/src/main/java/com/ardoq/adapter/ReferenceAdapter.java
+++ b/src/main/java/com/ardoq/adapter/ReferenceAdapter.java
@@ -47,10 +47,12 @@ public class ReferenceAdapter implements JsonDeserializer<Reference>, JsonSerial
         JsonElement jsonElement = gson().toJsonTree(reference, Reference.class);
         JsonObject jsonObject = jsonElement.getAsJsonObject();
         jsonObject.remove("_fields");
-        JsonUtils.removeReservedNullVaules(jsonObject);
-        for (Map.Entry<String, Object> s : fields.entrySet()) {
-            jsonObject.add(s.getKey(), jsonSerializationContext.serialize(s.getValue()));
-        }
+		JsonUtils.removeReservedNullVaules(jsonObject);
+		if (fields != null) {
+	        for (Map.Entry<String, Object> s : fields.entrySet()) {
+	            jsonObject.add(s.getKey(), jsonSerializationContext.serialize(s.getValue()));
+			}
+		}
         return jsonElement;
     }
 }


### PR DESCRIPTION
Hi @kristianhelgesen 
STill my issue on updating references.
I had to change the ReferenceAdapter to be able to update references which don't have fields.
All y components have specifi fields so I didn't fall in the same situation for components but as far as I can see, the same problem exists...
I noticed the same kind of problem if for instance the description is null.
I don't know if it's possible under normal conditions but we migrated a lot od applications into Ardoq using the Excel importer and for all applications and references which didn't have an explicit description, the description field seems to be null. I fixed that in ly own code by setting an empty string but it should also probably be checked. 